### PR TITLE
Rendre exemple matsum plus 'mesurable'

### DIFF
--- a/exple_matsum_Fortran/main.f90
+++ b/exple_matsum_Fortran/main.f90
@@ -13,9 +13,9 @@ program main
   real, allocatable, dimension(:,:,:) :: x,y,z
 
   ! data 
-  ni = 256
-  nj = 256
-  nk = 256
+  ni = 512
+  nj = 512
+  nk = 512
 
   ! allocate
   allocate(x(ni,nj,nk))


### PR DESCRIPTION
Avec ces modifs, l'exemple matsum monte à 10s, ce qui facilite l'observation de l'exécution.

Fixes #26 .